### PR TITLE
Argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Install rust and cargo from https://www.rust-lang.org/tools/install
 
 In the root folder launch
 
-```cargo run -- -f examples/example1.tikz```
+```cargo run -- examples/example1.tikz```
 
 That will load an automaton from the file ```examples/example1.tikz```,
 compute the maximal winning strategy for the random population control problem,
-displays the answer in the terminal, and produces tex and pdf reports `example1.tikz.tex` and `example1.tikz.pdf`.
+displays the answer in the terminal, including a winning strategy for positive instances.
 
 For dot files 
 
-```cargo run -- -i dot -f examples/bottleneck-1-ab.dot```
+```cargo run -- -i dot examples/bottleneck-1-ab.dot```
 
 Check the file ```examples.pdf``` at the root  which gives an overview of all available examples.
 
@@ -40,7 +40,7 @@ Two kind of input files can be processed by `shepherd`.
 ### Tikz files (as produced by finsm.io)
 
 - Create an automaton using https://finsm.io
-- Copy paste the export (in Tikz format) in some local file and give it as input to shepherd, using the `-f` option.
+- Copy paste the export (in Tikz format) in some local file and give it as input to shepherd.
 
 ### DOT files
 
@@ -60,27 +60,32 @@ See `examples/bottleneck-1-ab.dot` for a dot-representation equivalent to the si
 
 ## Output
 
-Each computation produces two outputs: a tex file and a pdf file.
-The `tex` output is formatted using the template `latex/solution.template.tex`.
-The `pdf`output is generated using `pdflatex`.
+Each computation produces and prints whether the given autonmaton is controllable or not.
+For positive instances, it will also give a representation of the winning strategy.
+You can optionally select which format this is given via the `-t` argument (either "tex" or "plain", defaults to "tex"),
+and give the path to where the solution is written via the `-o` argument (defaults to stdout).
+
+For a pretty latex report use
+
+```
+cargo run -- -f examples/example1.tikz -o report.tex && pdflatex report.tex
+```
 
 The states of the NFA can be automatically reordered in order to make the generated reports more readable.
 Either topologically
-```cargo run -- -s topological -i dot -f examples/bottleneck-2-staged.dot```
+```cargo run -- -s topological -i dot examples/bottleneck-2-staged.dot```
 or alphabetically
-```cargo run -- -s alphabetical -i dot -f examples/bottleneck-2-staged.dot```
+```cargo run -- -s alphabetical -i dot examples/bottleneck-2-staged.dot```
 
-The tex conversion and pdf compilations can be (optionally) turned off.
-Also the tex processor can also be modified.
 Run 
 
 ```cargo run -- -help```
 
 for all details.
 
-##Perfs
+## Perfs
 
 ```cargo build --release```
-```./target/release/shepherd -s topological -i dot -f examples/bottleneck-2-staged.dot```
+```./target/release/shepherd -s topological -i dot examples/bottleneck-2-staged.dot```
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ struct Args {
     filename: String,
 
     #[arg(
-        short,
-        long,
+        short='f',
+        long="from",
         value_enum,
         default_value = "tikz",
         help = "The input format"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::fs::write;
 use std::process;
 mod coef;
@@ -15,6 +15,13 @@ mod solver;
 mod strategy;
 use log::LevelFilter;
 
+
+#[derive(Debug,Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum OutputFormat {
+    Plain,
+    Tex,
+}
+
 #[derive(clap::Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -29,6 +36,16 @@ struct Args {
         help = "The input format"
     )]
     input_format: nfa::InputFormat,
+    
+    #[arg(
+        value_enum,
+        short='t',
+        long="to",
+        default_value = "plain",
+        help = "The output format"
+    )]
+    output_format: OutputFormat,
+
 
     #[arg(
         short,
@@ -64,6 +81,16 @@ fn main() {
         .init();
 
     let args = Args::parse();
+
+
+    match args.output_format {
+        OutputFormat::Tex => {
+            println!("Printing Tex");
+        }
+        OutputFormat::Plain => {
+            println!("plain text output");
+        }
+    }
 
     let nfa = nfa::Nfa::load_from_file(&args.filename, &args.input_format, &args.state_ordering);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,10 @@ enum OutputFormat {
 #[derive(clap::Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// The path to the input file
+    #[arg(
+        value_name = "AUTOMATON_FILE",
+        help = "path to the input"
+    )]
     filename: String,
 
     #[arg(
@@ -34,7 +37,6 @@ struct Args {
         long = "from",
         value_enum,
         default_value = "tikz",
-        value_name = "AUTOMATON_FILE",
         help = "The input format"
     )]
     input_format: nfa::InputFormat,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,22 +22,13 @@ struct Args {
     filename: String,
 
     #[arg(
-        short='f',
-        long="from",
+        short,
+        long,
         value_enum,
         default_value = "tikz",
         help = "The input format"
     )]
     input_format: nfa::InputFormat,
-
-    #[arg(
-        short='t',
-        long="to",
-        value_enum,
-        default_value = "tikz",
-        help = "The output format"
-    )]
-    output_format: nfa::InputFormat,
 
     #[arg(
         short,

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,16 +67,6 @@ struct Args {
         '{:?}' sorts states topologically.\n", nfa::StateOrdering::Input, nfa::StateOrdering::Alphabetical, nfa::StateOrdering::Topological)
     )]
     state_ordering: nfa::StateOrdering,
-
-    //adds an explanation to the help message
-    #[arg(long, action, help = "Do not generate tex output")]
-    no_tex_output: bool,
-
-    #[arg(long, action, help = "Do not generate pdf output")]
-    no_pdf_output: bool,
-
-    #[arg(long, default_value = "pdflatex", help = "The latex processor to use")]
-    latex_processor: String,
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,17 +18,26 @@ use log::LevelFilter;
 #[derive(clap::Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    #[arg(short, long, help = "The path to the input file")]
+    /// The path to the input file
     filename: String,
 
     #[arg(
-        short,
-        long,
+        short='f',
+        long="from",
         value_enum,
         default_value = "tikz",
         help = "The input format"
     )]
     input_format: nfa::InputFormat,
+
+    #[arg(
+        short='t',
+        long="to",
+        value_enum,
+        default_value = "tikz",
+        help = "The output format"
+    )]
+    output_format: nfa::InputFormat,
 
     #[arg(
         short,

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -12,7 +12,7 @@ pub struct Solution {
 }
 
 impl Solution {
-    pub fn generate_latex(&self, output_path: &str, tikz_path: Option<&str>) {
+    pub fn as_latex(&self, tikz_path: Option<&str>) -> String {
         let template_content = include_str!("../latex/solution.template.tex");
 
         // Create Tera instance
@@ -47,8 +47,7 @@ impl Solution {
 
         //Replace the utf8 symbol omega by \omega in therendered string
         let rendered = rendered.replace("ω", "w");
-        // Write to output file
-        fs::write(output_path, rendered).expect("Failed to write file");
+        rendered
     }
 }
 

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -58,10 +58,6 @@ impl fmt::Display for Solution {
         } else {
             "uncontrollable"
         };
-        writeln!(f, "Answer: {}", answer)?;
-        writeln!(f, "\n\nAutomaton:\n{}\n\n", self.nfa)?;
-        writeln!(f, "Maximal winning random walk:\n")?;
-        writeln!(f, "States:\n\t{}", self.nfa.states_str())?;
-        writeln!(f, "\n{}", self.maximal_winning_strategy)
+        writeln!(f, "Answer: {}", answer)
     }
 }


### PR DESCRIPTION
This is a proposal for restructuring the output as discussed in #32 .
There is no CSV output format yet, but it should be much easier to do after this refactoring.

New usage is as follows, also see the updated README.

```
Usage: shepherd [OPTIONS] <AUTOMATON_FILE>

Arguments:
  <AUTOMATON_FILE>  path to the input

Options:
  -f, --from <INPUT_FORMAT>
          The input format [default: tikz] [possible values: dot, tikz]
  -t, --to <OUTPUT_FORMAT>
          The output format [default: plain] [possible values: plain, tex]
  -o, --output <OUTPUT_FILE>
          where to write the strategy; defaults to stdout.
  -s, --state-ordering <STATE_ORDERING>
          The state reordering type.
          'Input' preserves input order.
          'Alphabetical' sorts by label.
          'Topological' sorts states topologically.
           [default: input] [possible values: input, alphabetical, topological]
  -h, --help
          Print help
  -V, --version
          Print version
```

The main changes are:

- the path to the automata file is now not optional
- I removed all tex-to-PDF stuff. You can still output as tex format and write to a file, then compile outside of this tool.

Let me know what you think, I'm happy to make changes.