### PR TITLE
95 lot of memory is needed onnfa 3dot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shepherd"
 version = "0.1.0"
 edition = "2021"
+default-run = "shepherd"
 
 [dependencies]
 log = "0.4.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 default-run = "shepherd"
 
 [dependencies]
-log = "0.4.27"
 env_logger = "0.11.8"
 regex = "1"
 clap = { version = "4.5.35", features = ["derive"] }
@@ -27,3 +26,6 @@ itertools = "0.14.0"
 name = "schaeppert"
 path = "src/iterative.rs"
 
+[dependencies.log]
+version = "0.4.27"
+features = ["release_max_level_info"]

--- a/latex/examples.tex
+++ b/latex/examples.tex
@@ -53,4 +53,10 @@ File {\tt bottleneck-1-abcde-complete.tikz}
 File {\tt bottleneck-2.tikz}
 
 \input{../examples/bottleneck-2.tikz} 
+
+\subsection{Bug 12}
+
+File {\tt bug12.tikz}
+
+\input{../examples/bug12.tikz} 
 \end{document}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,9 @@
 //! This module defines the command line interface (CLI) for the application.
 
+use crate::nfa;
+use crate::solver;
 use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
-use crate::solver;
-use crate::nfa;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum OutputFormat {
@@ -31,7 +31,7 @@ pub struct Args {
            short = 'v',
            long = "verbose",
            action = clap::ArgAction::Count,
-           help = "Increase verbosity level"
+           help = "Increase verbosity level. Default is warn only, -v is info,  -vv is debug, -vvv is trace"
        )]
     pub verbosity: u8,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,7 +73,7 @@ pub struct Args {
         long,
         value_enum,
         default_value = "strategy",
-        help = "Solver output specification."
+        help = "Solver output specification. Strategy will always compute the maximal winning strategy. Yes-no may be faster when the answer is positive, it uses a heuristic trying to find a simple strategy, which is winning but might not be maximal."
     )]
     pub solver_output: solver::SolverOutput,
 }

--- a/src/downset.rs
+++ b/src/downset.rs
@@ -47,7 +47,8 @@ static POSSIBLE_COEFS_CACHE: Lazy<Mutex<CoefsCollectionMemoizer>> = Lazy::new(||
 });
 
 fn compute_possible_coefs(possible_coefs: &CoefsCollection) -> impl Iterator<Item = Vec<Coef>> {
-    possible_coefs
+    trace!("compute_possible_coefs({:?})", possible_coefs);
+    let result = possible_coefs
         .iter()
         .map(|v| {
             let coef = v
@@ -67,7 +68,9 @@ fn compute_possible_coefs(possible_coefs: &CoefsCollection) -> impl Iterator<Ite
                     .collect(),
             }
         })
-        .multi_cartesian_product()
+        .multi_cartesian_product();
+    trace!("compute_possible_coefs done");
+    result
 }
 
 impl DownSet {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use clap::Parser;
+use log::info;
 use std::fs::File;
 use std::io;
 use std::io::Write;
-use log::info;
 
-use shepherd::solver;
 use shepherd::nfa;
+use shepherd::solver;
 
 mod cli;
 mod logging;

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -3,6 +3,7 @@ use crate::downset::DownSet;
 use crate::graph::Graph;
 use crate::ideal::Ideal;
 use crate::nfa;
+use log::trace;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -40,8 +41,18 @@ impl Strategy {
             // print!(".");
             //io::stdout().flush().unwrap();
             let edges = edges_per_letter.get(a).unwrap();
+            trace!(
+                "Restricting strategy for letter '{}' with downset {}",
+                a,
+                downset
+            );
             let safe_pre_image = safe.safe_pre_image(edges, maximal_finite_value);
             result |= downset.restrict_to(&safe_pre_image);
+            trace!(
+                "After restriction, downset for letter '{}' is {}",
+                a,
+                downset
+            );
         }
         result
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,8 +1,8 @@
-use shepherd::nfa;
-use shepherd::solver;
 use shepherd::coef::{C0, C1, C2, OMEGA};
 use shepherd::downset::DownSet;
 use shepherd::ideal::Ideal;
+use shepherd::nfa;
+use shepherd::solver;
 
 const EXAMPLE1: &str = include_str!("../examples/bottleneck-1-ab.tikz");
 const EXAMPLE1_COMPLETE: &str = include_str!("../examples/bottleneck-1-ab-complete.tikz");
@@ -138,4 +138,6 @@ fn test_bug12() {
         .unwrap();
     println!("{}", downsetb);
     assert!(downsetb.contains(&Ideal::from_vec(vec![C2, C0, C0, C0, C0, C0, C0, C0])));
+    assert!(downsetb.contains(&Ideal::from_vec(vec![C0, C1, C1, C0, C0, C0, C0, C0])));
+    assert!(downsetb.contains(&Ideal::from_vec(vec![C0, C0, C0, C0, C0, C0, C0, OMEGA])));
 }


### PR DESCRIPTION
Cache system is dropped.

Two new heuristics for iterating through candidate ideals when  computing the presafe image by a letter:
-  when finding a good ideal, avoid iterating in smaller ideals.
- when iterating on a coordinate 0 first, then omega, then finite coordinates by descending order. If it is losing for 0, there is no need to push further the exploration with other coordinates larger or equal.